### PR TITLE
Fix/m41 188 bu infobanner

### DIFF
--- a/templates/theme_boost/drawers.mustache
+++ b/templates/theme_boost/drawers.mustache
@@ -129,8 +129,6 @@
             </div>
             <!-- No Full-Header -->
             {{> theme_boost_union/infobanners }}
-             <!-- Maybe doch Full-Header -->
-
             {{#incourse}}
             {{{ output.full_header }}}
             {{/incourse}}

--- a/templates/theme_boost/drawers.mustache
+++ b/templates/theme_boost/drawers.mustache
@@ -128,6 +128,9 @@
                 {{/hasblocks}}
             </div>
             <!-- No Full-Header -->
+            {{> theme_boost_union/infobanners }}
+             <!-- Maybe doch Full-Header -->
+
             {{#incourse}}
             {{{ output.full_header }}}
             {{/incourse}}


### PR DESCRIPTION
Boost Union kann Infobanner anzeigen → wir brauchen es um maintenance Zeitraum anzukündigen im DLC 
Das Infobanner wird aber nur außerhalb des Kurses angezeigt - der Kurs selbst verwendet das childtheme.

- [x] lege Infobanner an → admin/settings.phpsection=theme_boost_union_content#theme_boost_union_infobanners_infobanner → enable Infobanner + etwas Text ins Feld

- [x] Darstellung des Infobanners im Course