### PR TITLE
fix sets color of mooin for primarylight install problem

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -259,7 +259,7 @@ if ((isset($ADMIN) && $hassiteconfig) || has_capability('theme/boost_union:confi
                         "theme_mooin4/primarylight",
                         get_string('primarylight', 'theme_mooin4'),
                         get_string("primarylight_desc", 'theme_mooin4'),
-                        get_config('theme_mooin4', 'primarylight_display') // Only stores the 6-digit HEX
+                        '#ccd9df'
                 ));
 
 


### PR DESCRIPTION
 - replaces circular set_ and get_config on primary_display