### PR TITLE
Fix/boost union4 5features

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -40,8 +40,8 @@ function theme_mooin4_get_main_scss_content($theme) {
 
     // As a start, get the compiled main SCSS from Boost Union.
     // This way, Boost Union Child will ship the same SCSS code as Boost Union itself.
-    $scss = theme_boost_union_get_main_scss_content(theme_config::load('boost_union'));
-
+    // TINJOHN Update 4.5 $scss = theme_boost_union_get_main_scss_content(theme_config::load('boost_union'));
+    $scss = theme_boost_union_get_main_scss_content(\core\output\theme_config::load('boost_union'));
     // And add Boost Union Child's main SCSS file to the stack.
     $scss .= file_get_contents($CFG->dirroot . '/theme/mooin4/scss/post.scss');
 
@@ -51,7 +51,7 @@ function theme_mooin4_get_main_scss_content($theme) {
 /**
  * Get SCSS to prepend.
  *
- * @param theme_config $theme The theme config object.
+ * @param \core\output\theme_config $theme The theme config object.
  * @return string
  */
 function theme_mooin4_get_pre_scss($theme) {
@@ -71,7 +71,7 @@ function theme_mooin4_get_pre_scss($theme) {
     // This way, we will add the pre SCSS code with the explicit use of the Boost Union configuration to the stack.
     $inheritanceconfig = get_config('theme_mooin4', 'prescssinheritance');
     if ($inheritanceconfig == THEME_MOOIN4_SETTING_INHERITANCE_DUPLICATE) {
-        $scss .= theme_boost_union_get_pre_scss(theme_config::load('boost_union'));
+        $scss .= theme_boost_union_get_pre_scss(\core\output\theme_config::load('boost_union'));
     }
 
     // And add Boost Union Child's pre SCSS file to the stack.
@@ -89,7 +89,7 @@ function theme_mooin4_get_pre_scss($theme) {
 /**
  * Inject additional SCSS.
  *
- * @param theme_config $theme The theme config object.
+ * @param \core\output\theme_config $theme The theme config object.
  * @return string
  */
 function theme_mooin4_get_extra_scss($theme) {
@@ -109,7 +109,7 @@ function theme_mooin4_get_extra_scss($theme) {
     // This way, we will add the extra SCSS code with the explicit use of the Boost Union configuration to the stack.
     $inheritanceconfig = get_config('theme_mooin4', 'extrascssinheritance');
     if ($inheritanceconfig == THEME_MOOIN4_SETTING_INHERITANCE_DUPLICATE) {
-        $scss .= theme_boost_union_get_extra_scss(theme_config::load('boost_union'));
+        $scss .= theme_boost_union_get_extra_scss(\core\output\theme_config::load('boost_union'));
     }
 
     /**********************************************************
@@ -133,12 +133,29 @@ function theme_mooin4_extend_busettingsoverview() {
         'label' => get_string('pluginname', 'theme_mooin4'),
         'desc' => get_string('settingsoverview_buc_desc', 'theme_mooin4'),
         'btn' => 'primary',
-        'url' => new \moodle_url('/admin/settings.php', ['section' => 'theme_mooin4']),
+        'url' => new \core\url('/admin/settings.php', ['section' => 'theme_boost_union_child']),
     ];
 
     return $cards;
 }
 
+/**
+ * Callback function which allows themes to alter the CSS URLs.
+ * We use this function to change the CSS URL to the flavour CSS URL if a flavour applies to the current page.
+ *
+ * @copyright 2024 Alexander Bias <bias@alexanderbias.de>
+ *
+ * @param mixed $urls The CSS URLs (passed as reference).
+ */
+function theme_mooin4_alter_css_urls(&$urls) {
+    global $CFG;
+
+    // Require Boost Union library.
+    require_once($CFG->dirroot.'/theme/boost_union/lib.php');
+
+    // Call Boost Union's theme_boost_union_alter_css_urls() function which implements the logic to change the CSS URL for flavours.
+    theme_boost_union_alter_css_urls($urls);
+}
 
 //NEW 
 function theme_mooin4_page_init(moodle_page $page) {

--- a/lib.php
+++ b/lib.php
@@ -40,7 +40,6 @@ function theme_mooin4_get_main_scss_content($theme) {
 
     // As a start, get the compiled main SCSS from Boost Union.
     // This way, Boost Union Child will ship the same SCSS code as Boost Union itself.
-    // TINJOHN Update 4.5 $scss = theme_boost_union_get_main_scss_content(theme_config::load('boost_union'));
     $scss = theme_boost_union_get_main_scss_content(\core\output\theme_config::load('boost_union'));
     // And add Boost Union Child's main SCSS file to the stack.
     $scss .= file_get_contents($CFG->dirroot . '/theme/mooin4/scss/post.scss');

--- a/settings.php
+++ b/settings.php
@@ -22,6 +22,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use theme_boost_union\admin_settingspage_tabs_with_tertiary;
+
 defined('MOODLE_INTERNAL') || die();
 
 /*
@@ -32,14 +34,13 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         // You will understand it as soon as you look at /theme/boost_union/settings.php.
         // This settings file here is built in a way that it adds another settings page to this existing settings
         // category. You can add all child-theme-specific settings to this settings page here.
-
         // However, there is still the $settings variable which is expected by Moodle core to be filled with the theme
         // settings and which is automatically linked from the theme selector page.
         // To avoid that there appears a broken "Boost Union Child" settings page, we redirect the user to a settings
         // overview page if he opens this page.
         $mainsettingspageurl = new moodle_url('/admin/settings.php', ['section' => 'themesettingmooin4']);
         if ($ADMIN->fulltree && $PAGE->has_set_url() && $PAGE->url->compare($mainsettingspageurl)) {
-                redirect(new moodle_url('/admin/settings.php', ['section' => 'theme_mooin4']));
+                redirect(new \core\url('/admin/settings.php', ['section' => 'theme_mooin4']));
         }
 
         // Create empty settings page structure to make the site administration work on non-admin pages.
@@ -72,9 +73,9 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
                 ];
 
 
-                // Create Boost Union Child settings page with tabs
+                // Create Boost Union Child settings page with tabs and tertiary navigation
                 // (and allow users with the theme/boost_union:configure capability to access it).
-                $page = new theme_boost_admin_settingspage_tabs(
+                $page = new admin_settingspage_tabs_with_tertiary(
                         'theme_mooin4',
                         get_string('configtitle', 'theme_mooin4', null, true),
                         'theme/boost_union:configure'

--- a/tests/behat/theme_mooin4.feature
+++ b/tests/behat/theme_mooin4.feature
@@ -4,12 +4,20 @@ Feature: Extending the theme_boost_union plugin with a child theme
   As developer
   I need to be able to build several kinds of extensions to Boost Union
 
-  Scenario: Skeleton scenario
-    # This Behat scenario is just a skeleton which is ready for extension.
-    # Grunt in Github actions would not be happy with a feature file without any scenario.
-    # Thus, we log in as admin to keep it happy.
+@javascript
+  Scenario: Allow admins to use the tertiary navigation to navigate between the individual Boost Union admin pages in Boost Union Child as well
     When I log in as "admin"
-
+    And I navigate to "Appearance > Boost Union > Accessibility" in site administration
+    And I should see "Accessibility" in the ".admin_settingspage_tabs_with_tertiary .dropdown-toggle" "css_element"
+    And I set the field "List of Boost Union settings pages" to "Boost Union Child"
+    Then "body#page-admin-setting-theme_boost_union_child" "css_element" should exist
+    And ".admin_settingspage_tabs_with_tertiary" "css_element" should exist
+    And ".admin_settingspage_tabs_with_tertiary" "css_element" should be visible
+    And I should see "Boost Union Child" in the ".admin_settingspage_tabs_with_tertiary .dropdown-toggle" "css_element"
+    And "h2:has(+ .admin_settingspage_tabs_with_tertiary)" "css_element" should not be visible
+    And I set the field "List of Boost Union settings pages" to "Accessibility"
+    And I should see "Accessibility" in the ".admin_settingspage_tabs_with_tertiary .dropdown-toggle" "css_element"
+    
     #################################################################
     # EXTENSION POINT:
     # Add your Behat scenarios here.

--- a/version.php
+++ b/version.php
@@ -28,8 +28,8 @@
 defined('MOODLE_INTERNAL') || die();                                                                                                
                                                                                                                                     
 
-$plugin->version   = 2025030300;        // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 'v4.4.'; 
+$plugin->version   = 2025080500;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 'v4.5.'; 
 
 // This is the version of Moodle this plugin requires.                                                                              
 $plugin->requires = 2022112805;                                                                                                   
@@ -37,4 +37,5 @@ $plugin->requires = 2022112805;
 // This is the component name of the plugin - it always starts with 'theme_'                                                        
 // for themes and should be the same as the name of the folder.                                                                     
 $plugin->component = 'theme_mooin4';
-$plugin->dependencies = ['theme_boost_union' => 2023010548];
+$plugin->dependencies = ['theme_boost_union' => 2024100725];
+


### PR DESCRIPTION
Achtung beim Testen: Versionsnummer ist schon upgedated - ggf. im Quellcode noch mal auf die Version des alten setzen

- [ ] sieht alles noch so aus, wie es soll
- [ ] neue feature flavour scss funktioniert
Erstelle einen Flavour /theme/boost_union/flavours/overview.php.
Ordne das Flavour einer Kurskategorie zu und ändere das scss, z.Bsp.:
<img width="613" height="530" alt="image" src="https://github.com/user-attachments/assets/62b17c4a-03a0-40df-8576-03f6589a96a0" />

In meinem Beispiel wird der Header komplett ausgeblendet.
 
