### PR TITLE
fix Bereichsfehler + some reset_all_caches + clean up old code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Moodle Design for the MOOIN 4.0 course format
 For more information go to https://github.com/ild-thl/moodle-format_mooin
 
-Branch mooin4bu is a child of Boost Union theme. Enables to use all the usefull functions of the parent theme.
+Branch mooin_405 and mooin4bu (for moodle 404) is a child of Boost Union theme. Enables to use all the usefull functions of the parent theme.

--- a/javascript/custom.js
+++ b/javascript/custom.js
@@ -1,7 +1,7 @@
 document.addEventListener("DOMContentLoaded", function () {
-    if (window.location.href.indexOf("admin/settings.php?section=themesettingmooin4") > -1) {
+    if (window.location.href.indexOf("admin/settings.php?section=theme_mooin4") > -1) {
 
-        console.log("Custom palette script loaded");
+        //console.log("Custom palette script loaded");
         //Get all elements für the custom-palette
         const paletteSelector = document.querySelector("#id_s_theme_mooin4_colorpalette");
         const colorPickers = document.querySelectorAll(".admin_colourpicker.clearfix");
@@ -72,5 +72,5 @@ document.addEventListener("DOMContentLoaded", function () {
         updateVisibility();
         updatePrimaryLight();
 
-    }
+    } 
 });

--- a/lib.php
+++ b/lib.php
@@ -132,7 +132,7 @@ function theme_mooin4_extend_busettingsoverview() {
         'label' => get_string('pluginname', 'theme_mooin4'),
         'desc' => get_string('settingsoverview_buc_desc', 'theme_mooin4'),
         'btn' => 'primary',
-        'url' => new \core\url('/admin/settings.php', ['section' => 'theme_boost_union_child']),
+        'url' => new \core\url('/admin/settings.php', ['section' => 'theme_mooin4']),
     ];
 
     return $cards;

--- a/settings.php
+++ b/settings.php
@@ -19,6 +19,7 @@
  *
  * @package    theme_mooin4
  * @copyright  2023 Daniel Poggenpohl <daniel.poggenpohl@fernuni-hagen.de> and Alexander Bias <bias@alexanderbias.de>
+ * @copyright  2025 Tina John <tina.john@th-luebeck> and Thomas Muschal <thomas.muschal@th-luebeck> (customizations)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
@@ -26,8 +27,10 @@ use theme_boost_union\admin_settingspage_tabs_with_tertiary;
 
 defined('MOODLE_INTERNAL') || die();
 
-/*
-if ($hassiteconfig || has_capability('theme/boost_union:configure', context_system::instance())) {
+require_once($CFG->libdir . '/adminlib.php');
+global $ADMIN;
+
+if ((isset($ADMIN) && $hassiteconfig) || has_capability('theme/boost_union:configure', context_system::instance())) {
 
         // How this file works:
         // Boost Union's settings are divided into multiple settings pages which resides in its own settings category.
@@ -39,12 +42,12 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
         // To avoid that there appears a broken "Boost Union Child" settings page, we redirect the user to a settings
         // overview page if he opens this page.
         $mainsettingspageurl = new moodle_url('/admin/settings.php', ['section' => 'themesettingmooin4']);
-        if ($ADMIN->fulltree && $PAGE->has_set_url() && $PAGE->url->compare($mainsettingspageurl)) {
+        if (is_object($ADMIN) && $ADMIN->fulltree && $PAGE->has_set_url() && $PAGE->url->compare($mainsettingspageurl)) {
                 redirect(new \core\url('/admin/settings.php', ['section' => 'theme_mooin4']));
         }
 
         // Create empty settings page structure to make the site administration work on non-admin pages.
-        if (!$ADMIN->fulltree) {
+        if (is_object($ADMIN) && !$ADMIN->fulltree) {
                 // Create Boost Union Child settings page
                 // (and allow users with the theme/boost_union:configure capability to access it).
                 $tab = new admin_settingpage(
@@ -57,7 +60,7 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
 
         // Create full settings page structure.
         // phpcs:disable moodle.ControlStructures.ControlSignature.Found
-        else if ($ADMIN->fulltree) {
+        else if (is_object($ADMIN) && $ADMIN->fulltree) {
 
                 // Require the necessary libraries.
                 require_once($CFG->dirroot . '/theme/boost_union/lib.php');
@@ -132,99 +135,14 @@ if ($hassiteconfig || has_capability('theme/boost_union:configure', context_syst
                 $setting->set_updatedcallback('theme_reset_all_caches');
                 $tab->add($setting);
 
-                // Add tab to settings page.
-                $page->add($tab);
 
-                /**********************************************************
-                 * EXTENSION POINT:
-                 * Add your Boost Union Child settings here.
-                 *********************************************************/
-
-// Add settings page to the admin settings category.
-
-/*
-                $ADMIN->add('theme_boost_union', $page);
-        }
-}
-*/
-
-
-require_once($CFG->libdir . '/adminlib.php');
-global $ADMIN;
-
-if ((isset($ADMIN) && $hassiteconfig) || has_capability('theme/boost_union:configure', context_system::instance())) {
-        $temp = new admin_settingpage('theme_mooin4', get_string('pluginname', 'theme_mooin4'));
-        if (is_object($ADMIN) && $ADMIN->fulltree) {
-                $temp = new admin_settingpage('themesettingmooin4', get_string('configtitle', 'theme_mooin4'));
-
-                // Require the necessary libraries.
-                require_once($CFG->dirroot . '/theme/boost_union/lib.php');
-                require_once($CFG->dirroot . '/theme/boost_union/locallib.php');
-                require_once($CFG->dirroot . '/theme/mooin4/lib.php');
-                require_once($CFG->dirroot . '/theme/mooin4/locallib.php');
-
-                // Prepare options array for select settings.
-                // Due to MDL-58376, we will use binary select settings instead of checkbox settings throughout this theme.
-                $yesnooption = [
-                        THEME_BOOST_UNION_SETTING_SELECT_YES => get_string('yes'),
-                        THEME_BOOST_UNION_SETTING_SELECT_NO => get_string('no'),
-                ];
-
-                $alertstring = get_string('settings_alert', 'theme_mooin4', null, true);
-                $temp->add(new admin_setting_heading(
-                        'alert_message',
-                        '',
-                        html_writer::tag('div', $alertstring, array('class' => 'alert alert-warning'))
-                ));
-                // Create inheritance heading.
-                $name = 'theme_mooin4/inheritanceheading';
-                $title = get_string('inheritanceheading', 'theme_mooin4', null, true);
-                $setting = new admin_setting_heading($name, $title, null);
-                $temp->add($setting);
-
-                // Prepare inheritance options.
-                $inheritanceoptions = [
-                        THEME_MOOIN4_SETTING_INHERITANCE_INHERIT =>
-                        get_string('inheritanceinherit', 'theme_mooin4'),
-                        THEME_MOOIN4_SETTING_INHERITANCE_DUPLICATE =>
-                        get_string('inheritanceduplicate', 'theme_mooin4'),
-                ];
-
-                // Setting: Pre SCSS inheritance setting.
-                $name = 'theme_mooin4/prescssinheritance';
-                $title = get_string('prescssinheritancesetting', 'theme_mooin4', null, true);
-                $description = get_string('prescssinheritancesetting_desc', 'theme_mooin4', null, true) . '<br />' .
-                        get_string('inheritanceoptionsexplanation', 'theme_mooin4', null, true);
-                $setting = new admin_setting_configselect(
-                        $name,
-                        $title,
-                        $description,
-                        THEME_MOOIN4_SETTING_INHERITANCE_INHERIT,
-                        $inheritanceoptions
-                );
-                $setting->set_updatedcallback('theme_reset_all_caches');
-                $temp->add($setting);
-
-                // Setting: Extra SCSS inheritance setting.
-                $name = 'theme_mooin4/extrascssinheritance';
-                $title = get_string('extrascssinheritancesetting', 'theme_mooin4', null, true);
-                $description = get_string('extrascssinheritancesetting_desc', 'theme_mooin4', null, true) . '<br />' .
-                        get_string('inheritanceoptionsexplanation', 'theme_mooin4', null, true);
-                $setting = new admin_setting_configselect(
-                        $name,
-                        $title,
-                        $description,
-                        THEME_MOOIN4_SETTING_INHERITANCE_INHERIT,
-                        $inheritanceoptions
-                );
-                $setting->set_updatedcallback('theme_reset_all_caches');
-                $temp->add($setting);
 
                 //color menu
                 $name = 'theme_mooin4/color_heading';
                 $title = get_string('color_heading', 'theme_mooin4', null, true);
                 $setting = new admin_setting_heading($name, $title, null);
-                $temp->add($setting);
+                $setting->set_updatedcallback('theme_reset_all_caches');
+                $tab->add($setting);
 
 
                 //Dropdown for Color Palettes
@@ -239,38 +157,46 @@ if ((isset($ADMIN) && $hassiteconfig) || has_capability('theme/boost_union:confi
                         'palette-pastellblue' => get_string('palette_pastellblue', 'theme_mooin4'),
                         'custom' => get_string('palette_custom', 'theme_mooin4')
                 ];
-                $temp->add(new admin_setting_configselect($name, $title, $description, $default, $choices));
+                $setting = new admin_setting_configselect($name, $title, $description, $default, $choices);
+                $setting->set_updatedcallback('theme_reset_all_caches');
+                $tab->add($setting);
 
 
                 // Infobox
                 $name = 'theme_mooin4/custompalette_info';
                 $title = ''; // Kein Titel nötig
                 $info = get_string('custompalette_info', 'theme_mooin4');
-                $temp->add(new admin_setting_heading($name, $title, $info));
+                $tab->add(new admin_setting_heading($name, $title, $info));
 
 
-                $temp->add(new admin_setting_configcolourpicker(
+                $setting = new admin_setting_configcolourpicker(
                         "theme_mooin4/primarycolor",
                         get_string('primarycolor', 'theme_mooin4'),
                         get_string("primarycolor_desc", 'theme_mooin4'),
                         '#004161'
-                ));
+                );
+                $setting->set_updatedcallback('theme_reset_all_caches');
+                $tab->add($setting);
 
-                $temp->add(new admin_setting_configcolourpicker(
+                $setting = new admin_setting_configcolourpicker(
                         "theme_mooin4/primarylight",
                         get_string('primarylight', 'theme_mooin4'),
                         get_string("primarylight_desc", 'theme_mooin4'),
                         '#ccd9df'
-                ));
+                );
+                $setting->set_updatedcallback('theme_reset_all_caches');
+                $tab->add($setting);
 
 
-                $temp->add(new admin_setting_configtext(
+                $setting = new admin_setting_configtext(
                         "theme_mooin4/primarylight_opacity",
                         get_string('primarylight_opacity', 'theme_mooin4'),
                         get_string("primarylight_opacity_desc", 'theme_mooin4'),
                         '50',
                         PARAM_INT
-                ));
+                );
+                $setting->set_updatedcallback('theme_reset_all_caches');
+                $tab->add($setting);
 
 
                 $colors = [
@@ -292,19 +218,26 @@ if ((isset($ADMIN) && $hassiteconfig) || has_capability('theme/boost_union:confi
 
                 // Loop through each color setting and create a color picker input for the admin
                 foreach ($colors as $name => $default) {
-                        $temp->add(new admin_setting_configcolourpicker(
+                        $setting = new admin_setting_configcolourpicker(
                                 "theme_mooin4/{$name}",
                                 get_string($name, 'theme_mooin4'),
                                 get_string("{$name}_desc", 'theme_mooin4'),
                                 $default
-                        ));
+                        );
+                        $setting->set_updatedcallback('theme_reset_all_caches');
+                        $tab->add($setting);
                 }
 
-                $ADMIN->add('themes', $temp);
+                
+
+                // Add tab to settings page.
+                $page->add($tab);
+                // Add settings page to the admin settings category.    
+                $ADMIN->add('theme_boost_union', $page);
         }
 }
 
-
+// Include custom JavaScript on admin pages.
 if (isset($PAGE)) {
-        $PAGE->requires->js(new moodle_url('/theme/mooin4/javascript/custom.js'));
-    }
+    $PAGE->requires->js(new moodle_url('/theme/mooin4/javascript/custom.js'));
+}

--- a/version.php
+++ b/version.php
@@ -37,5 +37,5 @@ $plugin->requires = 2022112805;
 // This is the component name of the plugin - it always starts with 'theme_'                                                        
 // for themes and should be the same as the name of the folder.                                                                     
 $plugin->component = 'theme_mooin4';
-$plugin->dependencies = ['theme_boost_union' => 2024100751];
+$plugin->dependencies = ['theme_boost_union' => 2024100729];
 


### PR DESCRIPTION
Stelle deine Instanz auf BoostUnion theme um.
Gehe auf admin/search.php#linkappearance (Webseite Admin -> Darstellung)

- [x] ganz unten steht ein [Mooin4 ALS Boost Union Child] link
- [x] klickt man darauf erhält man die settings und keinen Bereichsfehler
- [x] Farbauswahl funktioniert als Dropdown
- [x] Farbauswahl wird nach dem Speichern auch im Kurs umgesetzt
- [x] gehe wieder auf Darstellung -> Boost Union Einstellungsübersicht Menü erscheint auch dort
- [x] klickt man darauf erhält man die settings und keinen Bereichsfehler 
Folgendes sollte auch dort funktionieren wenn es vorher funktioniert hat 
 - [x] Farbauswahl funktioniert als Dropdown
- [x] Farbauswahl wird nach dem Speichern auch im Kurs umgesetzt
- [x] gleiches noch mal testen unter Darstellung -> Designs -> Mooin 4.x ALS Boost Union Child Zahnrad

