### PR TITLE
Fix: Einheitliches Dropdown-Highlighting auf allen Kursseiten

### DIFF
--- a/scss/post.scss
+++ b/scss/post.scss
@@ -1388,7 +1388,7 @@ body.limitedwidth #page.drawers.coursefrontpagelayout .main-inner {
   padding: 0 5px;
 }
 
-#page-course-view-mooin4 .dropdown-item:hover {
+.format-mooin4 .dropdown-item:hover {
   background-color: var(--secondary-color) !important;
   color: #fff !important;
   text-decoration: none;


### PR DESCRIPTION
## 🐛 Fix: Einheitliches Dropdown-Highlighting auf allen Kursseiten

### Problem
Dropdown-Item Hover auf Kursunterseiten teilweise anders als auf Kurshauptseite (wenn man auf "Mehr" klickt)

**Betroffene Seiten:**
- ❌ Lektionsseiten → Grauer Hover-Effekt
- ❌ Berichte → Grauer Hover-Effekt  
- ❌ Bewertungen → Grauer Hover-Effekt
- ❌ Teilnehmer/innen → Grauer Hover-Effekt
- ❌ Einstellungen → Grauer Hover-Effekt
- ✅ Hauptseite → Blauer Hover-Effekt (korrekt)

### Lösung
Selektor von `#page-course-view-mooin4` zu `.format-mooin4` geändert, damit der blaue Hover-Effekt auf **allen** Kursseiten konsistent angewendet wird.

**Geänderte Datei:**
- [scss/post.scss](cci:7://file:///Applications/MAMP/htdocs/moodle/theme/mooin4/scss/post.scss:0:0-0:0) (Zeile 1391)

Bitte folgende Seiten testen (Dropdown-Item Hover sollte überall blau sein):

- [x]  Kurshauptseite : Blau
- [x]  Berichte : Blau
- [x]  Bewertungen : Blau
- [x]  Teilnehmer/innen : Blau
- [x]  Kurseinstellungen : Blau