### PR TITLE
fix: add link icon in forum posts and news like in course content

### DIFF
--- a/scss/post.scss
+++ b/scss/post.scss
@@ -788,6 +788,22 @@ body.limitedwidth #page.drawers.coursefrontpagelayout .main-inner {
   }
 }
 
+/* ---- Link-Icon in Forumsbeiträgen (wie im Kursinhalt) ---- */
+.post-content-container,
+.post-message,
+.news-text {
+  a:not(:has(img))::after {
+    font-family: "bootstrap-icons";
+    content: "\F470";
+  }
+
+  /* Bild-Links: kein Icon */
+  a img+ ::after,
+  a:has(img)::after {
+    content: "";
+  }
+}
+
 #mooin4-breadcrumb-container,
 #mooin1pager-breadcrumb-container {
   margin: 0 1rem;


### PR DESCRIPTION
## Fix: Link-Icon in Forumsbeiträgen und Neuigkeiten ergänzt

### 🎯 Beschreibung
[Das Tickt in Jira](https://isy-thl.atlassian.net/browse/M41-287?atlOrigin=eyJpIjoiNWRkNTQ5YjBiYjA3NDhmMjk4MTcyNDgxNTkyZjJmZTgiLCJwIjoiaiJ9)
In Kurs-Beschreibungen (`.description`) wurde bereits ein Bootstrap-Icon (→) hinter Text-Links angezeigt, um Nutzern zu signalisieren, dass es sich um einen Link handelt. Diese Funktionalität fehlte jedoch in Forumsbeiträgen und Neuigkeiten.

Diese Änderung überträgt das gleiche Verhalten auf die Bereiche `.post-content-container`, `.post-message` und `.news-text`.

---

### 🔧 Änderungen
**Datei:**  
`scss/post.scss`

- Neuer CSS-Block für `.post-content-container`, `.post-message`, `.news-text`
- Text-Links erhalten automatisch das Bootstrap-Icon `\F470` (→) via `::after`
- Bild-Links (Links mit `<img>` als Inhalt) werden ausgenommen – kein Icon

---

### ✅ Test-Checkliste für den Reviewer
**Voraussetzung:** Theme-Cache leeren (Administration → Entwicklung → Caches löschen)

#### In Forumsbeiträgen
- [x] Einen Kurs mit einem Forum öffnen  
- [x] Einen Forumsbeitrag mit einem Text-Link öffnen → Pfeil-Icon erscheint nach dem Link  
- [x] Einen Forumsbeitrag mit einem Bild-Link (klickbares Bild) öffnen → kein Icon sichtbar  

#### In Neuigkeiten (News)
- [x] Auf der Kurs-Startseite einen Neuigkeiten-Eintrag mit einem Text-Link öffnen → Pfeil-Icon erscheint  
- [x] Einen Neuigkeiten-Eintrag mit einem Bild-Link öffnen → kein Icon sichtbar  

#### Kursinhalt — Regression Check
- [x] Kurs-Beschreibung mit Text-Link öffnen → Icon erscheint weiterhin korrekt  
- [x] Kurs-Beschreibung mit Bild-Link öffnen → kein Icon sichtbar (Verhalten unverändert)  