### PR TITLE
Fix/m41 291 fortschrittsanzeige optimierung

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -80,6 +80,7 @@
     display: -webkit-box !important;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
+    line-clamp: 2;
     white-space: normal;
     //max-height: 3rem;
 
@@ -106,6 +107,7 @@
     display: -webkit-box !important;
     -webkit-line-clamp: 4;
     -webkit-box-orient: vertical;
+    line-clamp: 4;
     white-space: normal;
     //max-height: 5rem;
   }
@@ -149,6 +151,7 @@
   .bi-gear-fill {
     font-size: 1rem;
     color: var(--primary);
+
     &:hover {
       color: var(--dark-color);
     }
@@ -170,18 +173,18 @@
 }
 
 
-  .badges-list li a::before {
-    font-family: "bootstrap-icons";
-    content: "\F430";
-    color: var(--primary-color);
-    position: absolute;
-    background-color: white;
-    border-radius: 50%;
-    font-size: 1.5rem;
-    left: 3.5rem;
-    top: -2.5rem;
-    z-index: 1;
-  }
+.badges-list li a::before {
+  font-family: "bootstrap-icons";
+  content: "\F430";
+  color: var(--primary-color);
+  position: absolute;
+  background-color: white;
+  border-radius: 50%;
+  font-size: 1.5rem;
+  left: 3.5rem;
+  top: -2.5rem;
+  z-index: 1;
+}
 
 
 .subpage--badges {
@@ -285,11 +288,13 @@ ol.breadcrumb {
   margin-left: 0px !important;
 }
 
-.new-badge-layer, .new-certificate-layer {
+.new-badge-layer,
+.new-certificate-layer {
   position: relative;
 }
 
-.new-badge-layer::after, .new-certificate-layer::after {
+.new-badge-layer::after,
+.new-certificate-layer::after {
   content: "";
   position: absolute;
   top: 0;
@@ -302,10 +307,28 @@ ol.breadcrumb {
   z-index: 3;
 }
 
-body.editing #page-header{
+body.editing #page-header {
   display: none !important;
 }
 
 .btn.info-tip .bi-info-circle-fill {
   color: var(--primary);
+}
+
+.notyetavailable-badge {
+  background-color: #f8f9fa;
+  color: #6c757d;
+  border: 1px solid #dee2e6;
+  padding: 0.1rem 0.4rem;
+  font-size: 0.75rem;
+  border-radius: 0.25rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.15rem;
+  vertical-align: middle;
+  margin-bottom: 2px;
+
+  .bi-lock-fill {
+    font-size: 0.85rem;
+  }
 }

--- a/scss/post.scss
+++ b/scss/post.scss
@@ -788,6 +788,22 @@ body.limitedwidth #page.drawers.coursefrontpagelayout .main-inner {
   }
 }
 
+/* ---- Link-Icon in Forumsbeiträgen (wie im Kursinhalt) ---- */
+.post-content-container,
+.post-message,
+.news-text {
+  a:not(:has(img))::after {
+    font-family: "bootstrap-icons";
+    content: "\F470";
+  }
+
+  /* Bild-Links: kein Icon */
+  a img+ ::after,
+  a:has(img)::after {
+    content: "";
+  }
+}
+
 #mooin4-breadcrumb-container,
 #mooin1pager-breadcrumb-container {
   margin: 0 1rem;


### PR DESCRIPTION
# PR: [M41-291] UI-Erweiterung für gesperrte Lektionen (MOOIN 4 Theme)

## Übersicht
Diese Änderungen fügen das Styling für das neue "Noch nicht verfügbar" Badge hinzu.
[M41-291](https://isy-thl.atlassian.net/jira/software/projects/M41/boards/20?jql=assignee%20%3D%20712020%3A8007062f-3823-4fc3-b1e4-e4cbccfe083c&selectedIssue=M41-291)

### Änderungen:
*   **SCSS (`scss/_utilities.scss`):**
    *   Hinzufügen der Klasse `.notyetavailable-badge`.
    *   Styling für ein dezentes, graues Badge mit besserer Sichtbarkeit, um Lernenden zu signalisieren, dass Inhalte existieren, aber noch nicht freigeschaltet sind.
*   **Korrekturen:** Behebung von Lint-Warnungen bezüglich `line-clamp` für bessere Browser-Kompatibilität.

### Test-Checkliste:
* [ ] **Badge-Visualisierung:** Erstelle eine Sektion (sichtbar, aber gesperrt).
    * *Ergebnis:* Ein graues Badge **"Noch nicht verfügbar"** muss im Kursindex (links) und im Sektions-Header erscheinen.
* [ ] **Sprachtest:** Stelle Moodle auf Englisch um.
    * *Ergebnis:* Das Badge muss den Text **"Not yet available"** anzeigen.
