### PR TITLE
Kapitel darstellung kaputt

### DIFF
--- a/scss/_hvp.scss
+++ b/scss/_hvp.scss
@@ -2,26 +2,37 @@
     .flex-fill.description-inner {
         width: 100%;
     }
+
     iframe {
         width: 100%;
         min-width: 100%;
     }
+
     .activity-item {
         padding: 0;
         border: none;
     }
-    
+
 }
+
+.hvp-completion-btn {
+    display: flex;
+    justify-content: flex-end;
+    padding: 0.5rem 0;
+}
+
 #page-mod-hvp-embed {
     .embedded-main {
         h2:first-of-type {
             display: none;
-          }
+        }
+
         .activity-header {
             display: none;
         }
     }
 }
+
 .parent-iframe {
     transition: height 0.1s ease-out;
 

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -80,6 +80,7 @@
     display: -webkit-box !important;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
+    line-clamp: 2;
     white-space: normal;
     //max-height: 3rem;
 
@@ -106,6 +107,7 @@
     display: -webkit-box !important;
     -webkit-line-clamp: 4;
     -webkit-box-orient: vertical;
+    line-clamp: 4;
     white-space: normal;
     //max-height: 5rem;
   }
@@ -149,6 +151,7 @@
   .bi-gear-fill {
     font-size: 1rem;
     color: var(--primary);
+
     &:hover {
       color: var(--dark-color);
     }
@@ -170,18 +173,18 @@
 }
 
 
-  .badges-list li a::before {
-    font-family: "bootstrap-icons";
-    content: "\F430";
-    color: var(--primary-color);
-    position: absolute;
-    background-color: white;
-    border-radius: 50%;
-    font-size: 1.5rem;
-    left: 3.5rem;
-    top: -2.5rem;
-    z-index: 1;
-  }
+.badges-list li a::before {
+  font-family: "bootstrap-icons";
+  content: "\F430";
+  color: var(--primary-color);
+  position: absolute;
+  background-color: white;
+  border-radius: 50%;
+  font-size: 1.5rem;
+  left: 3.5rem;
+  top: -2.5rem;
+  z-index: 1;
+}
 
 
 .subpage--badges {
@@ -285,11 +288,13 @@ ol.breadcrumb {
   margin-left: 0px !important;
 }
 
-.new-badge-layer, .new-certificate-layer {
+.new-badge-layer,
+.new-certificate-layer {
   position: relative;
 }
 
-.new-badge-layer::after, .new-certificate-layer::after {
+.new-badge-layer::after,
+.new-certificate-layer::after {
   content: "";
   position: absolute;
   top: 0;
@@ -302,10 +307,28 @@ ol.breadcrumb {
   z-index: 3;
 }
 
-body.editing #page-header{
+body.editing #page-header {
   display: none !important;
 }
 
 .btn.info-tip .bi-info-circle-fill {
   color: var(--primary);
+}
+
+.notyetavailable-badge {
+  background-color: #f8f9fa;
+  color: #6c757d;
+  border: 1px solid #dee2e6;
+  padding: 0.1rem 0.4rem;
+  font-size: 0.75rem;
+  border-radius: 0.25rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.15rem;
+  vertical-align: middle;
+  margin-bottom: 2px;
+
+  .bi-lock-fill {
+    font-size: 0.85rem;
+  }
 }

--- a/scss/post.scss
+++ b/scss/post.scss
@@ -788,6 +788,22 @@ body.limitedwidth #page.drawers.coursefrontpagelayout .main-inner {
   }
 }
 
+/* ---- Link-Icon in Forumsbeiträgen (wie im Kursinhalt) ---- */
+.post-content-container,
+.post-message,
+.news-text {
+  a:not(:has(img))::after {
+    font-family: "bootstrap-icons";
+    content: "\F470";
+  }
+
+  /* Bild-Links: kein Icon */
+  a img+ ::after,
+  a:has(img)::after {
+    content: "";
+  }
+}
+
 #mooin4-breadcrumb-container,
 #mooin1pager-breadcrumb-container {
   margin: 0 1rem;

--- a/settings.php
+++ b/settings.php
@@ -28,7 +28,7 @@ use theme_boost_union\admin_settingspage_tabs_with_tertiary;
 defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->libdir . '/adminlib.php');
-global $ADMIN;
+global $ADMIN, $PAGE;
 
 if ((isset($ADMIN) && $hassiteconfig) || has_capability('theme/boost_union:configure', context_system::instance())) {
 

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 
-$plugin->version   = 2026041416;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025081300;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->release   = 'v4.5.';
 
 // This is the version of Moodle this plugin requires.

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 
-$plugin->version   = 2025081300;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2026041416;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->release   = 'v4.5.';
 
 // This is the version of Moodle this plugin requires.


### PR DESCRIPTION
## Zusammenfassung
Dieser PR behebt eine Regression in der Kapitel-/Aktivitätsdarstellung im Theme `mooin4`, insbesondere bei der Anzeige von H5P-Inhalten und dem Completion-Button.

## Tickte Nummer :
[267](https://isy-thl.atlassian.net/browse/M41-297)

## Was wurde geändert

### `scss/_hvp.scss`
- H5P-bezogene Layout-/Style-Regeln wurden angepasst, um die Kapitel-/Aktivitätsdarstellung zu stabilisieren.
- Eine eigene Regel `.hvp-completion-btn` wurde ergänzt, damit der Completion-Bereich konsistent ausgerichtet ist.
- Vorhandene Style-Blöcke für eingebettete H5P-Ausgaben wurden bereinigt/strukturiert.

**Warum:**  
Die bisherige Styling-Konstellation führte zu einer fehlerhaften bzw. uneinheitlichen Darstellung. Mit den SCSS-Anpassungen wird das erwartete Verhalten wiederhergestellt.

### `settings.php`
- Globale Deklaration geändert von:
  - `global $ADMIN;`
  - auf `global $ADMIN, $PAGE;`

**Warum:**  
`$PAGE` wird in dieser Datei verwendet (u. a. URL-Vergleich und JS-Einbindung). Die globale Deklaration verhindert undefinierte Zugriffe und stellt die stabile Ausführung sicher.

### `version.php`
- Plugin-Version erhöht:
  - von `2025081300`
  - auf `2026041416`

**Warum:**  
Moodle erkennt Theme-Änderungen zuverlässig über die Versionsnummer. Der Versionssprung stellt sicher, dass die Änderungen bei Update/Deployment korrekt verarbeitet und Caches konsistent erneuert werden.

## Testplan
- [x] Branch `Kapitel-Darstellung-kaputt` auschecken.
- [x] Moodle-Caches leeren (insbesondere Theme-/SCSS-Cache).
- [x] Kurs mit Kapiteln/Abschnitten öffnen und prüfen, dass die Darstellung nicht mehr kaputt ist.