### PR TITLE
Constrain forum image sizes in mooin4 theme.

### DIFF
--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -93,6 +93,15 @@
     p {
       margin: 0;
     }
+
+    img {
+      max-width: 7rem;
+      max-height: 3.5rem;
+      width: auto;
+      height: auto;
+      object-fit: contain;
+      vertical-align: middle;
+    }
   }
 
   .discussion-link {
@@ -110,6 +119,15 @@
     line-clamp: 4;
     white-space: normal;
     //max-height: 5rem;
+
+    img {
+      max-width: 7rem;
+      max-height: 3.5rem;
+      width: auto;
+      height: auto;
+      object-fit: contain;
+      vertical-align: middle;
+    }
   }
 }
 

--- a/scss/post.scss
+++ b/scss/post.scss
@@ -834,6 +834,20 @@ body.limitedwidth #page.drawers.coursefrontpagelayout .main-inner {
   a:has(img)::after {
     content: "";
   }
+
+}
+
+.path-mod-forum {
+  .post-content-container,
+  .post-message {
+    img {
+      max-width: 12rem;
+      max-height: 12rem;
+      width: auto;
+      height: auto;
+      object-fit: contain;
+    }
+  }
 }
 
 #mooin4-breadcrumb-container,


### PR DESCRIPTION
## Ticketnummer
[298](https://isy-thl.atlassian.net/browse/M41-298?atlOrigin=eyJpIjoiNjNkNzFlNzY5ODg1NDMyMmI4M2U1Yzk2YzQ0YjMxMGQiLCJwIjoiaiJ9)
## Zusammenfassung
- Begrenzt die Bildgrößen im mooin4-Theme, damit das Layout sowohl in Vorschaukarten als auch auf Forenseiten stabil bleibt.
- Fügt gezielte Größenlimits hinzu für:
  - Bilder im Vorschautext von Diskussion/News
  - Bilder im Forenbeitragsinhalt auf `mod/forum`-Seiten

## Warum
Nach der korrekten Foren-Formatierung wurden eingebettete Bilder zwar angezeigt, konnten aber zu groß dargestellt werden.  
Die neuen Style-Regeln halten die Darstellung kompakt und konsistent, ohne Bilder auszublenden.

## Änderungen
- `scss/_utilities.scss` aktualisiert:
  - Bildgrößenbegrenzung in `.news-text img` für Vorschau-Bereiche ergänzt.
- `scss/post.scss` aktualisiert:
  - Auf `.path-mod-forum` begrenzte Bildgrößenregel für `.post-content-container` und `.post-message` ergänzt.

## Testplan
- [x] Prüfen, dass das Bild in der Vorschau kompakt und sauber ausgerichtet ist.
- [x] Prüfen, dass das Bild dort begrenzt dargestellt wird und das Layout nicht sprengt.
- [x] Prüfen, dass Link-/Textdarstellung unverändert bleibt.
- [x] Moodle-Caches leeren und Darstellung erneut prüfen.