### PR TITLE
Fix/safari error 153 h5poverride

### DIFF
--- a/javascript/h5p-init-wrapper.js
+++ b/javascript/h5p-init-wrapper.js
@@ -10,7 +10,7 @@ H5P.init = function (target) {
   originalH5PInit.call(this, target);
   
   // Then re-process iframes with the corrected writeDocument
-  H5P.jQuery('iframe.h5p-iframe', target).each(function () {
+  H5P.jQuery('iframe.h5p-iframe:not(.mooin-h5p-jquery-override)', target).each(function () {
     const iframe = this;
     const $iframe = H5P.jQuery(iframe);
     
@@ -20,18 +20,21 @@ H5P.init = function (target) {
       ? contentData.metadata.defaultLanguage : 'en';
 
     const writeDocument = function () {
+      const dochtml = '<!doctype html><html class="h5p-iframe" lang="' + contentLanguage + '"><head>' + H5P.getHeadTags(contentId) + '</head><body><div class="h5p-content" data-content-id="' + contentId + '"/></body></html>';
       // Use srcdoc for modern browsers (Safari 5.1+, all others)
+      // This avoids XSS warnings and doesn't require a static file
       if ('srcdoc' in iframe) {
-        iframe.srcdoc = '<!doctype html><html class="h5p-iframe" lang="' + contentLanguage + '"><head>' + H5P.getHeadTags(contentId) + '</head><body><div class="h5p-content" data-content-id="' + contentId + '"/></body></html>';
+        iframe.srcdoc = dochtml;
       } else {
         // Fallback for older browsers
         iframe.contentDocument.open();
-        iframe.contentDocument.write('<!doctype html><html class="h5p-iframe" lang="' + contentLanguage + '"><head>' + H5P.getHeadTags(contentId) + '</head><body><div class="h5p-content" data-content-id="' + contentId + '"/></body></html>');
+        iframe.contentDocument.write(dochtml);
         iframe.contentDocument.close();
       }
     };
-
-    $iframe.addClass('mooin-h5p-init-override');
+    
+    $iframe.addClass('h5p-initialized');
+    $iframe.addClass('mooin-h5p-jquery-override');
     
     if (iframe.contentDocument !== null) {
       writeDocument();

--- a/javascript/h5p-override-h5pinit.js
+++ b/javascript/h5p-override-h5pinit.js
@@ -51,6 +51,10 @@ H5P.init = function (target) {
       metadata: contentData.metadata
     };
 
+    // Apply theme density
+    let density = H5PIntegration.theme?.density ?? 'large';
+    $element.addClass('h5p-' + density);
+
     H5P.getUserData(contentId, 'state', function (err, previousState) {
       if (previousState) {
         library.userDatas = {
@@ -129,7 +133,11 @@ H5P.init = function (target) {
       var $actions = actionBar.getDOMElement();
 
       actionBar.on('reuse', function () {
-        H5P.openReuseDialog($actions, contentData, library, instance, contentId);
+        H5P.openReuseDialog($actions, contentData, {
+          library: contentData.library,
+          params: JSON.parse(contentData.jsonContent),
+          metadata: contentData.metadata
+        }, instance, contentId);
         instance.triggerXAPI('accessed-reuse');
       });
       actionBar.on('copyrights', function () {
@@ -326,27 +334,33 @@ H5P.init = function (target) {
     const contentLanguage = contentData && contentData.metadata && contentData.metadata.defaultLanguage
       ? contentData.metadata.defaultLanguage : 'en';
 
+
     const writeDocument = function () {
+      const dochtml = '<!doctype html><html class="h5p-iframe" lang="' + contentLanguage + '"><head>' + H5P.getHeadTags(contentId) + '</head><body><div class="h5p-content" data-content-id="' + contentId + '"/></body></html>';
       // Use srcdoc for modern browsers (Safari 5.1+, all others)
       // This avoids XSS warnings and doesn't require a static file
       if ('srcdoc' in iframe) {
-        iframe.srcdoc = '<!doctype html><html class="h5p-iframe" lang="' + contentLanguage + '"><head>' + H5P.getHeadTags(contentId) + '</head><body><div class="h5p-content" data-content-id="' + contentId + '"/></body></html>';
+        iframe.srcdoc = dochtml;
       } else {
         // Fallback for older browsers
         iframe.contentDocument.open();
-        iframe.contentDocument.write('<!doctype html><html class="h5p-iframe" lang="' + contentLanguage + '"><head>' + H5P.getHeadTags(contentId) + '</head><body><div class="h5p-content" data-content-id="' + contentId + '"/></body></html>');
+        iframe.contentDocument.write(dochtml);
         iframe.contentDocument.close();
       }
     };
+    
 
     $iframe.addClass('h5p-initialized');
-    $iframe.addClass('mooin-h5p-init-override'); // Add a custom class to the iframe for styling purposes
-    
-    // Call immediately if contentDocument is accessible
-    if (iframe.contentDocument !== null) {
+    $iframe.addClass('mooin-h5p-init-override');
+
+    if (iframe.contentDocument === null) {
+      // In some Edge cases the iframe isn't always loaded when the page is ready.
+      $iframe.on('load', writeDocument);
+      $iframe.attr('src', 'about:blank');
+    }
+    else {
       writeDocument();
-    } else {
-        $iframe.on('load', writeDocument);
     }
   });
 };
+

--- a/javascript/h5p-override-h5pinit.js
+++ b/javascript/h5p-override-h5pinit.js
@@ -1,0 +1,352 @@
+/** @namespace */
+var H5P = window.H5P = window.H5P || {};
+
+/**
+ * Initialize H5P content.
+ * Scans for ".h5p-content" in the document and initializes H5P instances where found.
+ *
+ * @param {Object} target DOM Element
+ */
+H5P.init = function (target) {
+  // Useful jQuery object.
+  if (H5P.$body === undefined) {
+    H5P.$body = H5P.jQuery(document.body);
+  }
+
+  // Determine if we can use full screen
+  if (H5P.fullscreenSupported === undefined) {
+    /**
+     * Use this variable to check if fullscreen is supported. Fullscreen can be
+     * restricted when embedding since not all browsers support the native
+     * fullscreen, and the semi-fullscreen solution doesn't work when embedded.
+     * @type {boolean}
+     */
+    H5P.fullscreenSupported = !H5PIntegration.fullscreenDisabled && !H5P.fullscreenDisabled && (!(H5P.isFramed && H5P.externalEmbed !== false) || !!(document.fullscreenEnabled || document.webkitFullscreenEnabled || document.mozFullScreenEnabled));
+    // -We should consider document.msFullscreenEnabled when they get their
+    // -element sizing corrected. Ref. https://connect.microsoft.com/IE/feedback/details/838286/ie-11-incorrectly-reports-dom-element-sizes-in-fullscreen-mode-when-fullscreened-element-is-within-an-iframe
+    // Update: Seems to be no need as they've moved on to Webkit
+  }
+
+  // Deprecated variable, kept to maintain backwards compatability
+  if (H5P.canHasFullScreen === undefined) {
+    /**
+     * @deprecated since version 1.11
+     * @type {boolean}
+     */
+    H5P.canHasFullScreen = H5P.fullscreenSupported;
+  }
+
+  // H5Ps added in normal DIV.
+  H5P.jQuery('.h5p-content:not(.h5p-initialized)', target).each(function () {
+    var $element = H5P.jQuery(this).addClass('h5p-initialized');
+    var $container = H5P.jQuery('<div class="h5p-container"></div>').appendTo($element);
+    var contentId = $element.data('content-id');
+    var contentData = H5PIntegration.contents['cid-' + contentId];
+    if (contentData === undefined) {
+      return H5P.error('No data for content id ' + contentId + '. Perhaps the library is gone?');
+    }
+    var library = {
+      library: contentData.library,
+      params: JSON.parse(contentData.jsonContent),
+      metadata: contentData.metadata
+    };
+
+    H5P.getUserData(contentId, 'state', function (err, previousState) {
+      if (previousState) {
+        library.userDatas = {
+          state: previousState
+        };
+      }
+      else if (previousState === null && H5PIntegration.saveFreq) {
+        // Content has been reset. Display dialog.
+        delete contentData.contentUserData;
+        var dialog = new H5P.Dialog('content-user-data-reset', 'Data Reset', '<p>' + H5P.t('contentChanged') + '</p><p>' + H5P.t('startingOver') + '</p><div class="h5p-dialog-ok-button" tabIndex="0" role="button">OK</div>', $container);
+        H5P.jQuery(dialog).on('dialog-opened', function (event, $dialog) {
+
+          var closeDialog = function (event) {
+            if (event.type === 'click' || event.which === 32) {
+              dialog.close();
+              H5P.deleteUserData(contentId, 'state', 0);
+            }
+          };
+
+          $dialog.find('.h5p-dialog-ok-button').click(closeDialog).keypress(closeDialog);
+          H5P.trigger(instance, 'resize');
+        }).on('dialog-closed', function () {
+          H5P.trigger(instance, 'resize');
+        });
+        dialog.open();
+      }
+      // If previousState is false we don't have a previous state
+    });
+
+    // Create new instance.
+    var instance = H5P.newRunnable(library, contentId, $container, true, {standalone: true});
+
+    H5P.offlineRequestQueue = new H5P.OfflineRequestQueue({instance: instance});
+
+    // Check if we should add and display a fullscreen button for this H5P.
+    if (contentData.fullScreen == 1 && H5P.fullscreenSupported) {
+      H5P.jQuery(
+        '<div class="h5p-content-controls">' +
+          '<div role="button" ' +
+                'tabindex="0" ' +
+                'class="h5p-enable-fullscreen" ' +
+                'aria-label="' + H5P.t('fullscreen') + '" ' +
+                'title="' + H5P.t('fullscreen') + '">' +
+          '</div>' +
+        '</div>')
+        .prependTo($container)
+          .children()
+          .click(function () {
+            H5P.fullScreen($container, instance);
+          })
+        .keydown(function (e) {
+          if (e.which === 32 || e.which === 13) {
+            H5P.fullScreen($container, instance);
+            return false;
+          }
+        })
+      ;
+    }
+
+    /**
+     * Create action bar
+     */
+    var displayOptions = contentData.displayOptions;
+    var displayFrame = false;
+    if (displayOptions.frame) {
+      // Special handling of copyrights
+      if (displayOptions.copyright) {
+        var copyrights = H5P.getCopyrights(instance, library.params, contentId, library.metadata);
+        if (!copyrights) {
+          displayOptions.copyright = false;
+        }
+      }
+
+      // Create action bar
+      var actionBar = new H5P.ActionBar(displayOptions);
+      var $actions = actionBar.getDOMElement();
+
+      actionBar.on('reuse', function () {
+        H5P.openReuseDialog($actions, contentData, library, instance, contentId);
+        instance.triggerXAPI('accessed-reuse');
+      });
+      actionBar.on('copyrights', function () {
+        var dialog = new H5P.Dialog('copyrights', H5P.t('copyrightInformation'), copyrights, $container);
+        dialog.open(true);
+        instance.triggerXAPI('accessed-copyright');
+      });
+      actionBar.on('embed', function () {
+        H5P.openEmbedDialog($actions, contentData.embedCode, contentData.resizeCode, {
+          width: $element.width(),
+          height: $element.height()
+        }, instance);
+        instance.triggerXAPI('accessed-embed');
+      });
+
+      if (actionBar.hasActions()) {
+        displayFrame = true;
+        $actions.insertAfter($container);
+      }
+    }
+
+    $element.addClass(displayFrame ? 'h5p-frame' : 'h5p-no-frame');
+
+    // Keep track of when we started
+    H5P.opened[contentId] = new Date();
+
+    // Handle events when the user finishes the content. Useful for logging exercise results.
+    H5P.on(instance, 'finish', function (event) {
+      if (event.data !== undefined) {
+        H5P.setFinished(contentId, event.data.score, event.data.maxScore, event.data.time);
+      }
+    });
+
+    // Listen for xAPI events.
+    H5P.on(instance, 'xAPI', H5P.xAPICompletedListener);
+
+    // Auto save current state if supported
+    if (H5PIntegration.saveFreq !== false && (
+        instance.getCurrentState instanceof Function ||
+        typeof instance.getCurrentState === 'function')) {
+
+      var saveTimer, save = function () {
+        var state = instance.getCurrentState();
+        if (state !== undefined) {
+          H5P.setUserData(contentId, 'state', state, {deleteOnChange: true});
+        }
+        if (H5PIntegration.saveFreq) {
+          // Continue autosave
+          saveTimer = setTimeout(save, H5PIntegration.saveFreq * 1000);
+        }
+      };
+
+      if (H5PIntegration.saveFreq) {
+        // Start autosave
+        saveTimer = setTimeout(save, H5PIntegration.saveFreq * 1000);
+      }
+
+      // xAPI events will schedule a save in three seconds.
+      H5P.on(instance, 'xAPI', function (event) {
+        var verb = event.getVerb();
+        if (verb === 'completed' || verb === 'progressed') {
+          clearTimeout(saveTimer);
+          saveTimer = setTimeout(save, 3000);
+        }
+      });
+    }
+
+    if (H5P.isFramed) {
+      var resizeDelay;
+      if (H5P.externalEmbed === false) {
+        // Internal embed
+        // Make it possible to resize the iframe when the content changes size. This way we get no scrollbars.
+        var iframe = window.frameElement;
+        var resizeIframe = function () {
+          if (window.parent.H5P.isFullscreen) {
+            return; // Skip if full screen.
+          }
+
+          // Retain parent size to avoid jumping/scrolling
+          var parentHeight = iframe.parentElement.style.height;
+          iframe.parentElement.style.height = iframe.parentElement.clientHeight + 'px';
+
+          // Note:  Force layout reflow
+          //        This fixes a flickering bug for embedded content on iPads
+          //        @see https://github.com/h5p/h5p-moodle-plugin/issues/237
+          iframe.getBoundingClientRect();
+
+          // Reset iframe height, in case content has shrinked.
+          iframe.style.height = '1px';
+
+          // Resize iframe so all content is visible.
+          iframe.style.height = (iframe.contentDocument.body.scrollHeight) + 'px';
+
+          // Free parent
+          iframe.parentElement.style.height = parentHeight;
+        };
+
+        H5P.on(instance, 'resize', function () {
+          // Use a delay to make sure iframe is resized to the correct size.
+          clearTimeout(resizeDelay);
+          resizeDelay = setTimeout(function () {
+            resizeIframe();
+          }, 1);
+        });
+      }
+      else if (H5P.communicator) {
+        // External embed
+        var parentIsFriendly = false;
+
+        // Handle that the resizer is loaded after the iframe
+        H5P.communicator.on('ready', function () {
+          H5P.communicator.send('hello');
+        });
+
+        // Handle hello message from our parent window
+        H5P.communicator.on('hello', function () {
+          // Initial setup/handshake is done
+          parentIsFriendly = true;
+
+          // Make iframe responsive
+          document.body.style.height = 'auto';
+
+          // Hide scrollbars for correct size
+          document.body.style.overflow = 'hidden';
+
+          // Content need to be resized to fit the new iframe size
+          H5P.trigger(instance, 'resize');
+        });
+
+        // When resize has been prepared tell parent window to resize
+        H5P.communicator.on('resizePrepared', function () {
+          H5P.communicator.send('resize', {
+            scrollHeight: document.body.scrollHeight
+          });
+        });
+
+        H5P.communicator.on('resize', function () {
+          H5P.trigger(instance, 'resize');
+        });
+
+        H5P.on(instance, 'resize', function () {
+          if (H5P.isFullscreen) {
+            return; // Skip iframe resize
+          }
+
+          // Use a delay to make sure iframe is resized to the correct size.
+          clearTimeout(resizeDelay);
+          resizeDelay = setTimeout(function () {
+            // Only resize if the iframe can be resized
+            if (parentIsFriendly) {
+              H5P.communicator.send('prepareResize', {
+                scrollHeight: document.body.scrollHeight,
+                clientHeight: document.body.clientHeight
+              });
+            }
+            else {
+              H5P.communicator.send('hello');
+            }
+          }, 0);
+        });
+      }
+    }
+
+    if (!H5P.isFramed || H5P.externalEmbed === false) {
+      // Resize everything when window is resized.
+      H5P.jQuery(window.parent).resize(function () {
+        H5P.trigger(instance, 'resize');
+      });
+    }
+
+    H5P.instances.push(instance);
+
+    // Resize content.
+    H5P.trigger(instance, 'resize');
+
+    // Logic for hiding focus effects when using mouse
+    $element.addClass('using-mouse');
+    $element.on('mousedown keydown keyup', function (event) {
+      $element.toggleClass('using-mouse', event.type === 'mousedown');
+    });
+
+    if (H5P.externalDispatcher) {
+      H5P.externalDispatcher.trigger('initialized');
+    }
+  });
+
+  // Insert H5Ps that should be in iframes.
+  H5P.jQuery('iframe.h5p-iframe:not(.h5p-initialized)', target).each(function () {
+    const iframe = this;
+    const $iframe = H5P.jQuery(iframe);
+
+    const contentId = $iframe.data('content-id');
+    const contentData = H5PIntegration.contents['cid-' + contentId];
+    const contentLanguage = contentData && contentData.metadata && contentData.metadata.defaultLanguage
+      ? contentData.metadata.defaultLanguage : 'en';
+
+    const writeDocument = function () {
+      // Use srcdoc for modern browsers (Safari 5.1+, all others)
+      // This avoids XSS warnings and doesn't require a static file
+      if ('srcdoc' in iframe) {
+        iframe.srcdoc = '<!doctype html><html class="h5p-iframe" lang="' + contentLanguage + '"><head>' + H5P.getHeadTags(contentId) + '</head><body><div class="h5p-content" data-content-id="' + contentId + '"/></body></html>';
+      } else {
+        // Fallback for older browsers
+        iframe.contentDocument.open();
+        iframe.contentDocument.write('<!doctype html><html class="h5p-iframe" lang="' + contentLanguage + '"><head>' + H5P.getHeadTags(contentId) + '</head><body><div class="h5p-content" data-content-id="' + contentId + '"/></body></html>');
+        iframe.contentDocument.close();
+      }
+    };
+
+    $iframe.addClass('h5p-initialized');
+    $iframe.addClass('mooin-h5p-init-override'); // Add a custom class to the iframe for styling purposes
+    
+    // Call immediately if contentDocument is accessible
+    if (iframe.contentDocument !== null) {
+      writeDocument();
+    } else {
+        $iframe.on('load', writeDocument);
+    }
+  });
+};

--- a/javascript/h5p-override-h5pjquery.js
+++ b/javascript/h5p-override-h5pjquery.js
@@ -1,0 +1,42 @@
+/** @namespace */
+var H5P = window.H5P = window.H5P || {};
+
+// Store the original H5P.init
+var originalH5PInit = H5P.init;
+
+// Override with custom version that has the working srcdoc fallback
+H5P.init = function (target) {
+  // Call the original init first for everything else
+  originalH5PInit.call(this, target);
+  
+  // Then re-process iframes with the corrected writeDocument
+  H5P.jQuery('iframe.h5p-iframe', target).each(function () {
+    const iframe = this;
+    const $iframe = H5P.jQuery(iframe);
+    
+    const contentId = $iframe.data('content-id');
+    const contentData = H5PIntegration.contents['cid-' + contentId];
+    const contentLanguage = contentData && contentData.metadata && contentData.metadata.defaultLanguage
+      ? contentData.metadata.defaultLanguage : 'en';
+
+    const writeDocument = function () {
+      // Use srcdoc for modern browsers (Safari 5.1+, all others)
+      if ('srcdoc' in iframe) {
+        iframe.srcdoc = '<!doctype html><html class="h5p-iframe" lang="' + contentLanguage + '"><head>' + H5P.getHeadTags(contentId) + '</head><body><div class="h5p-content" data-content-id="' + contentId + '"/></body></html>';
+      } else {
+        // Fallback for older browsers
+        iframe.contentDocument.open();
+        iframe.contentDocument.write('<!doctype html><html class="h5p-iframe" lang="' + contentLanguage + '"><head>' + H5P.getHeadTags(contentId) + '</head><body><div class="h5p-content" data-content-id="' + contentId + '"/></body></html>');
+        iframe.contentDocument.close();
+      }
+    };
+
+    $iframe.addClass('mooin-h5p-init-override');
+    
+    if (iframe.contentDocument !== null) {
+      writeDocument();
+    } else {
+      $iframe.on('load', writeDocument);
+    }
+  });
+};

--- a/settings.php
+++ b/settings.php
@@ -238,4 +238,9 @@ if ((isset($ADMIN) && $hassiteconfig) || has_capability('theme/boost_union:confi
 // Include custom JavaScript on admin pages.
 if (isset($PAGE)) {
     $PAGE->requires->js(new moodle_url('/theme/mooin4/javascript/custom.js'));
+    // solange h5p.js der h5plib den Bug ignoriert, dass Safari kein 
+    // about:blank mit anschließender Füllung mit cross-site unterstützt, muss das hier überschrieben werden
+    // eigentlich nur die static 
+    $PAGE->requires->js(new moodle_url('/theme/mooin4/javascript/h5p-override-h5pinit.js'));
+    //$PAGE->requires->js(new moodle_url('/theme/mooin4/javascript/h5p-override-h5pjquery.js'));
 }

--- a/settings.php
+++ b/settings.php
@@ -238,9 +238,16 @@ if ((isset($ADMIN) && $hassiteconfig) || has_capability('theme/boost_union:confi
 // Include custom JavaScript on admin pages.
 if (isset($PAGE)) {
     $PAGE->requires->js(new moodle_url('/theme/mooin4/javascript/custom.js'));
-    // solange h5p.js der h5plib den Bug ignoriert, dass Safari kein 
-    // about:blank mit anschließender Füllung mit cross-site unterstützt, muss das hier überschrieben werden
-    // eigentlich nur die static 
+        // H5P verwendet in h5p.js zunächst about:blank und befüllt anschließend das
+        // iframe. Safari unterstützt dieses Vorgehen bei Cross-Site-Inhalten nicht
+        // zuverlässig. Deshalb wird H5P.init vorübergehend überschrieben.
+        //
+        // Der vollständige Override verarbeitet die Iframes nur einmal und ist
+        // dadurch etwas performanter. Er dupliziert jedoch große Teile der
+        // H5P-Core-Implementierung und muss bei H5P-Updates mitgepflegt werden.
     $PAGE->requires->js(new moodle_url('/theme/mooin4/javascript/h5p-override-h5pinit.js'));
-    //$PAGE->requires->js(new moodle_url('/theme/mooin4/javascript/h5p-override-h5pjquery.js'));
+        // Fallback bei Konflikten mit dem vollständigen Override: Der Wrapper ruft
+        // die originale H5P.init-Funktion auf und passt anschließend nur die
+        // iframe-Erzeugung an. Er überschreibt nicht H5P.jQuery:
+    // $PAGE->requires->js(new moodle_url('/theme/mooin4/javascript/h5p-init-wrapper.js'));
 }


### PR DESCRIPTION
H5P verwendet in h5p.js zunächst about:blank und befüllt anschließend das iframe. Safari unterstützt dieses Vorgehen bei Cross-Site-Inhalten nicht zuverlässig. 

2 Fixes von mir : 
- ein override der kompletten H5P.init v128
- ein wrapper , der die Frames gefixed neulädt - nur Fallback auskommentiert für schnelles Handeln
 
Der vollständige Override verarbeitet die Iframes nur einmal und ist  dadurch etwas performanter als die Fallbackmethode. Er dupliziert jedoch große Teile der H5P-Core-Implementierung und muss bei H5P-Updates mitgepflegt werden.

Der Fix ist seit 3 Wochen doch schon im h5p-php-library Repo aber nur im moodle branch, den aber nur mod_hvp im Moment nutzt. Moodle nativ sourcen die lib selbst rein und vermutlich den stable branch. 
Der Fix ist also wohl grundsätzlich gut.

mod_hvp muss aber komplett neuinstalliert werden, damit sich das submodule - eben die h5p library updatet - so musste ich es lokal und damit im DLC Hub machen.   

- [ ]  teste auf einem nicht mac, ob die h5p Aktivitäten noch funktionieren
- [ ]  teste am besten auf einem mac, dass eingebettete Videos in h5p Aktivitäten (interactive video) zum Beispiel im Safari Browser ohne Error 153 eingebettet werden. - ich habe es schon auf lernen.dev.dlc.sh installiert, da funktioniert es. 



